### PR TITLE
support chained mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,12 @@ function ready(flagOrFunction) {
       process.nextTick(callback);
     });
   }
+  return this;
 }
 
 function mixin(object) {
   object.ready = ready;
+  return object;
 }
 
 module.exports = mixin;

--- a/test/index.js
+++ b/test/index.js
@@ -67,4 +67,13 @@ describe('ready', function() {
       done();
     }, 10);
   });
+
+  it('should support chained mode', function(done) {
+    // it useful for `ready(obj).ready(fn).on('foo', fn).once('bar', fn);`
+    var obj = ready({});
+    obj.ready(false)
+    .ready(done)
+    .ready(false)
+    .ready(true);
+  });
 });


### PR DESCRIPTION
It's useful for `ready(obj).ready(fn).on('foo', fn).once('bar', fn);`
